### PR TITLE
Adds vue.js to integrations section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ sidebar_categories:
     - how-it-works
   Integrations:
     - meteor
+    - vue
 
 # not sure if we should rename this?
 github_repo: apollostack/docs

--- a/source/meteor.md
+++ b/source/meteor.md
@@ -1,10 +1,10 @@
 ---
-title: Meteor integration
+title: Meteor
 order: 152
 description: Specifics about using Apollo in your Meteor application.
 ---
 
-The Apollo client and server tools are published on NPM, which makes them available to all JavaScript applications, including those written with [Meteor](https://www.meteor.com/) 1.3 and above. When using Meteor with Apollo, you can use those npm packages directly, or you can use the [`apollo` Atmosphere package](https://github.com/apollostack/meteor-integration/), which simplifies things for you.
+The Apollo client and server tools are published on Npm, which makes them available to all JavaScript applications, including those written with [Meteor](https://www.meteor.com/) 1.3 and above. When using Meteor with Apollo, you can use those npm packages directly, or you can use the [`apollo` Atmosphere package](https://github.com/apollostack/meteor-integration/), which simplifies things for you.
 
 To install `apollo`, run these commands:
 

--- a/source/vue.md
+++ b/source/vue.md
@@ -1,0 +1,7 @@
+---
+title: Vue.js
+order: 160
+description: Specifics about using Apollo in your Vue.js application.
+---
+
+A [Vue.js](https://vuejs.org/) integration is maintained by Guillaume Chau. See the Github [repository](https://github.com/Akryum/vue-apollo) for more details.


### PR DESCRIPTION
@stubailo What do you think of adding integrations like this? Another option might be to have an 'Other' or 'External' sibling to 'Meteor' and simply list them in there.