### PR TITLE
Network interface : document chaining use() and useAfter() calls

### DIFF
--- a/source/network.md
+++ b/source/network.md
@@ -173,6 +173,17 @@ const client = new ApolloClient({
 This example shows how you can use more than one afterware to make multiple/separate
 modifications to the response being processed in the form of a chain.
 
+<h3 id="networkInterfaceChaining" title="Chaining">Chaining</h3>
+
+It is possible to build a chain made of `.use()` and `.useAfter()` calls in any order :
+
+```js
+networkInterface.use([exampleWare1])
+  .use([exampleWare2])
+  .useAfter([exampleWare3])
+  .useAfter([exampleWare4])
+  .use([exampleWare5]);
+```
 
 <h2 id="custom-network-interface">Custom network interface</h2>
 


### PR DESCRIPTION
This PR adds documentation about chaining use() and useAfter() calls on a network interface. The corresponding PR which adds this feature is https://github.com/apollostack/apollo-client/pull/860
Remark : this is a new feature.