### PR TITLE
Add meteor accounts information

### DIFF
--- a/source/meteor.md
+++ b/source/meteor.md
@@ -104,3 +104,8 @@ Returns an [`options` object](http://dev.apollodata.com/core/apollo-client-api.h
 
 
 It will use the same port as your Meteor server. Don't put a route or static asset at the same path as the Apollo route or the GraphiQL route if in use (defaults are `/graphql` and `/graphiql` respectively).
+
+## Accounts
+
+You may still use the authentication based on DDP (Meteor's default data layer) and apollo will send the current user's login token to the GraphQL server with each request. But if you want to use only GraphQL in your app you can use [nicolaslopezj:apollo-accounts](https://github.com/nicolaslopezj/meteor-apollo-accounts). This package uses the Meteor Accounts methods in GraphQL, it's compatible with the accounts you have saved in your database and you may use apollo-accounts and Meteor's DPP accounts at the same time.
+


### PR DESCRIPTION
This adds a section in Meteor integration about Accounts. It recommends the use of https://github.com/nicolaslopezj/meteor-apollo-accounts for GraphQL only authentication.