### PR TITLE
Add ember-apollo-client to Ember integration page

### DIFF
--- a/source/ember.md
+++ b/source/ember.md
@@ -4,4 +4,7 @@ order: 160
 description: Specifics about using Apollo in your Ember application.
 ---
 
-An [Ember](http://emberjs.com/) integration is maintained by Jeff Levy. See the Github [repository](https://github.com/jlevycpa/ember-apollo) for more details.
+There are two [Ember](http://emberjs.com/) integrations available:
+
+* [ember-apollo-client](https://github.com/bgentry/ember-apollo-client) is maintained by Blake Gentry.
+* [ember-apollo](https://github.com/jlevycpa/ember-apollo) is maintained by Jeff Levy.


### PR DESCRIPTION
I made an Ember addon for apollo-client: https://github.com/bgentry/ember-apollo-client

I wasn't sure what the right way to add this to the docs was since there are multiple Ember addons for apollo-client. I was going to put mine second since it was not the first one published, but ultimately I decided it made sense to put it first since it's a cleaner integration, is more fleshed out, and is more tested.

Up to you folks how you want to handle this :v: